### PR TITLE
Show menu for copying one time passwords on tap

### DIFF
--- a/Tofu/AccountCell.swift
+++ b/Tofu/AccountCell.swift
@@ -128,4 +128,14 @@ class AccountCell: UITableViewCell {
         progressView.tintColor = account.password.timeIntervalRemainingForDate(date) < 5 ?
             .red : tintColor
     }
+
+    override func copy(_ sender: Any?) {
+        guard let valueLabelText = valueLabel.text else { return }
+
+        UIPasteboard.general.string = valueLabelText.replacingOccurrences(of: " ", with: "")
+    }
+
+    override var canBecomeFirstResponder: Bool {
+        return true
+    }
 }

--- a/Tofu/AccountCell.swift
+++ b/Tofu/AccountCell.swift
@@ -130,9 +130,9 @@ class AccountCell: UITableViewCell {
     }
 
     override func copy(_ sender: Any?) {
-        guard let valueLabelText = valueLabel.text else { return }
+        guard let labelText = valueLabel.text else { return }
 
-        UIPasteboard.general.string = valueLabelText.replacingOccurrences(of: " ", with: "")
+        UIPasteboard.general.string = labelText.replacingOccurrences(of: " ", with: "")
     }
 
     override var canBecomeFirstResponder: Bool {

--- a/Tofu/AccountSearchResultsViewController.swift
+++ b/Tofu/AccountSearchResultsViewController.swift
@@ -42,7 +42,7 @@ class AccountSearchResultsViewController: UITableViewController, AccountUpdateDe
             let menuController = UIMenuController.shared
 
             // If you tap the same cell twice, this condition prevents the menu from being
-            // hidden and then instantly shown again otherwise causing an unpleasant flash.
+            // hidden and then instantly shown again causing an unpleasant flash.
             //
             // Since the cell could already be the first responder (from previously showing
             // its menu and then scrolling the table view) and the menu could already be

--- a/Tofu/AccountsViewController.swift
+++ b/Tofu/AccountsViewController.swift
@@ -214,7 +214,7 @@ class AccountsViewController: UITableViewController {
                 let menuController = UIMenuController.shared
 
                 // If you tap the same cell twice, this condition prevents the menu from being
-                // hidden and then instantly shown again otherwise causing an unpleasant flash.
+                // hidden and then instantly shown again causing an unpleasant flash.
                 //
                 // Since the cell could already be the first responder (from previously showing
                 // its menu and then scrolling the table view) and the menu could already be

--- a/Tofu/AccountsViewController.swift
+++ b/Tofu/AccountsViewController.swift
@@ -30,6 +30,18 @@ class AccountsViewController: UITableViewController {
         updater.startUpdating()
 
         updateEditing()
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(deselectSelectedTableViewRow),
+            name: .UIMenuControllerWillHideMenu,
+            object: nil)
+    }
+
+    @objc func deselectSelectedTableViewRow() {
+        if let indexPath = tableView.indexPathForSelectedRow {
+            tableView.deselectRow(at: indexPath, animated: true)
+        }
     }
 
     @IBAction func addAccount(_ sender: Any) {
@@ -186,9 +198,34 @@ class AccountsViewController: UITableViewController {
     // MARK: UITableViewDelegate
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        tableView.deselectRow(at: indexPath, animated: true)
-        if let cell = tableView.cellForRow(at: indexPath) as? AccountCell {
-            performSegue(withIdentifier: "EditAccountSegue", sender: cell)
+        if tableView.isEditing {
+            tableView.deselectRow(at: indexPath, animated: true)
+
+            if let cell = tableView.cellForRow(at: indexPath) as? AccountCell {
+                performSegue(withIdentifier: "EditAccountSegue", sender: cell)
+            }
+        } else { // Not editing
+            if let cell = tableView.cellForRow(at: indexPath) {
+                guard let cellSuperview = cell.superview else {
+                    assertionFailure("The cell does not seem to be in the view hierarchy. How is that even possible!?")
+                    return
+                }
+
+                let menuController = UIMenuController.shared
+
+                // If you tap the same cell twice, this condition prevents the menu from being
+                // hidden and then instantly shown again otherwise causing an unpleasant flash.
+                //
+                // Since the cell could already be the first responder (from previously showing
+                // its menu and then scrolling the table view) and the menu could already be
+                // visible for another cell, we make sure to check both values.
+                if !(cell.isFirstResponder && menuController.isMenuVisible) {
+                    cell.becomeFirstResponder()
+
+                    menuController.setTargetRect(cell.frame, in: cellSuperview)
+                    menuController.setMenuVisible(true, animated: true)
+                }
+            }
         }
     }
 
@@ -206,8 +243,7 @@ class AccountsViewController: UITableViewController {
                             forRowAt indexPath: IndexPath, withSender sender: Any?) {
         if action == #selector(copy(_:)) {
             let cell = tableView.cellForRow(at: indexPath) as! AccountCell
-            UIPasteboard.general.string = cell.valueLabel.text?
-                .replacingOccurrences(of: " ", with: "")
+            cell.copy(self)
         }
     }
 }

--- a/Tofu/Base.lproj/Main.storyboard
+++ b/Tofu/Base.lproj/Main.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="nkx-Kv-qqz">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="nkx-Kv-qqz">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -75,7 +75,7 @@
         <scene sceneID="eJy-We-MJo">
             <objects>
                 <tableViewController definesPresentationContext="YES" id="bOu-aX-zXX" customClass="AccountsViewController" customModule="Tofu" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" allowsSelection="NO" allowsSelectionDuringEditing="YES" rowHeight="84" sectionHeaderHeight="28" sectionFooterHeight="28" id="CH7-nX-hsd">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" allowsSelectionDuringEditing="YES" rowHeight="84" sectionHeaderHeight="28" sectionFooterHeight="28" id="CH7-nX-hsd">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -589,7 +589,7 @@
         <scene sceneID="aqF-ES-gLR">
             <objects>
                 <tableViewController storyboardIdentifier="AccountSearchResultsViewController" id="sSp-X7-dXp" customClass="AccountSearchResultsViewController" customModule="Tofu" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" allowsSelection="NO" rowHeight="84" sectionHeaderHeight="28" sectionFooterHeight="28" id="rcD-1Q-m4Q">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="84" sectionHeaderHeight="28" sectionFooterHeight="28" id="rcD-1Q-m4Q">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>


### PR DESCRIPTION
Previously this menu was only shown when long-pressing on account cells.
Now only a single normal tap a cell is required.

This resolves #7.